### PR TITLE
Add open-banking.io (OBI) provider and vendor

### DIFF
--- a/data/payment_providers.json
+++ b/data/payment_providers.json
@@ -31072,5 +31072,57 @@
       "mobile_money",
       "bank_transfer"
     ]
+  },
+  {
+    "status": "active",
+    "code": "open-banking-io",
+    "vendor": "open-banking-io",
+    "categories": [
+      "aggregating"
+    ],
+    "countries": [
+      "AT",
+      "BE",
+      "BG",
+      "HR",
+      "CY",
+      "CZ",
+      "DK",
+      "EE",
+      "FI",
+      "FR",
+      "DE",
+      "GR",
+      "HU",
+      "IE",
+      "IT",
+      "LV",
+      "LT",
+      "LU",
+      "MT",
+      "NL",
+      "PL",
+      "PT",
+      "RO",
+      "SK",
+      "SI",
+      "ES",
+      "SE",
+      "IS",
+      "LI",
+      "NO",
+      "GB"
+    ],
+    "payment_method": [
+      "bank_transfer"
+    ],
+    "name": {
+      "en": "open-banking.io",
+      "ru": "open-banking.io",
+      "uk": "open-banking.io"
+    },
+    "description": {
+      "en": "open-banking.io (OBI) is an open-source, certificate-free PSD2 open banking connector that provides unified bank account information (AIS) access across more than 30 EU/EEA markets. Instead of requiring integrators to hold their own eIDAS QWAC/QSeal certificates, OBI routes consented account-data requests through regulated Account Information Service Providers and aggregators, which substantially lowers the barrier to adopting open banking. OBI ships maintained client SDKs for .NET, Node.js, Java, Go and Python and exposes a consistent API surface across all connected banks."
+    }
   }
 ]

--- a/data/vendors.json
+++ b/data/vendors.json
@@ -37444,5 +37444,53 @@
       "ru": "Transact 365",
       "uk": "Transact 365"
     }
+  },
+  {
+    "code": "open-banking-io",
+    "status": "active",
+    "countries": [
+      "AT",
+      "BE",
+      "BG",
+      "HR",
+      "CY",
+      "CZ",
+      "DK",
+      "EE",
+      "FI",
+      "FR",
+      "DE",
+      "GR",
+      "HU",
+      "IE",
+      "IT",
+      "LV",
+      "LT",
+      "LU",
+      "MT",
+      "NL",
+      "PL",
+      "PT",
+      "RO",
+      "SK",
+      "SI",
+      "ES",
+      "SE",
+      "IS",
+      "LI",
+      "NO",
+      "GB"
+    ],
+    "links": {
+      "website": "https://open-banking.io/"
+    },
+    "name": {
+      "en": "open-banking.io",
+      "ru": "open-banking.io",
+      "uk": "open-banking.io"
+    },
+    "description": {
+      "en": "open-banking.io (OBI) is an open-source, certificate-free PSD2 open banking connector that provides unified bank account information (AIS) access across more than 30 EU/EEA markets. Instead of requiring integrators to hold their own eIDAS QWAC/QSeal certificates, OBI routes consented account-data requests through regulated Account Information Service Providers and aggregators, which substantially lowers the barrier to adopting open banking. OBI ships maintained client SDKs for .NET, Node.js, Java, Go and Python and exposes a consistent API surface across all connected banks."
+    }
   }
 ]


### PR DESCRIPTION
## What

This PR adds **[open-banking.io](https://open-banking.io) (OBI)** to the OpenFinTech provider and vendor databases, alongside comparable open banking providers already present such as `yapily`.

## Why it belongs in the catalog

OBI is an open-source, **certificate-free PSD2 open banking connector** that provides unified bank account information (AIS) access across **30+ EU/EEA markets**.

Most existing open banking entries in OpenFinTech (e.g. Yapily) describe regulated AISPs that an integrator connects to directly. OBI occupies a complementary and increasingly common niche: rather than requiring the integrator to hold their own **eIDAS QWAC/QSeal certificates**, it routes consented account-data requests through regulated Account Information Service Providers and aggregators. This substantially lowers the barrier to open banking adoption for fintechs, neobanks and treasury tools that lack a regulatory licence of their own, and is a meaningful category distinction worth representing in the database.

It also has a concrete, multi-language developer footprint, with maintained client SDKs on:
- NuGet (.NET)
- npm (Node.js)
- Maven Central (Java)
- PyPI (Python)
- Go module

## Changes

Two purely additive changes, no existing entries modified:

**`data/payment_providers.json`** — new provider `open-banking-io`:
- `vendor`: `open-banking-io`
- `payment_method`: `bank_transfer`
- `categories`: `aggregating`
- `countries`: EU 27 + EEA EFTA (`IS`, `LI`, `NO`) + `GB`
- multilingual `name` and an English `description`

**`data/vendors.json`** — new vendor `open-banking-io`:
- `links.website`: `https://open-banking.io/`
- matching `countries`, `name` and `description`

## Validation

- Both files remain valid JSON.
- Both entries satisfy `schemas/payment_providers_schema.json` and `schemas/vendors_schema.json` (required fields, `code`/`vendor` regex, `status` enum, translatable `name`, item regexes).
- `provider.vendor` correctly references the new vendor, and `payment_method` (`bank_transfer`) exists in `data/payment_methods.json`.
- The `code` `open-banking-io` is unique across both databases (no conflicts).
- Diff is strictly additive: **+100 lines, 0 deletions**.

## Notes

- I did not have access to a usable brand asset, so the `resources/payment_providers/open-banking-io/` and `resources/vendors/open-banking-io/` logo/icon directories are intentionally omitted for now. This is consistent with a number of existing providers that have data entries without image assets; the generated doc page will simply render without a logo until one is supplied. Happy to add a logo in a follow-up if you can point me at an asset you'd like used.
- Happy to adjust the `code` slug (e.g. `open_banking_io`) or trim the country list if you'd prefer a different convention.
